### PR TITLE
reproduce and fix bug that is caused when float is running into scien…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='stempeg',
-    version='0.1.6',
+    version='0.1.7',
     description='Read and write stem multistream audio files',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/stempeg/read.py
+++ b/stempeg/read.py
@@ -4,9 +4,28 @@ import os
 import json
 import warnings
 import tempfile as tmp
+import decimal
 import soundfile as sf
 
 DEVNULL = open(os.devnull, 'w')
+
+
+
+def float_to_str(f, precision=12):
+    """
+    Convert the given float to a string,
+    without resorting to scientific notation
+    """
+
+    # create a new context for this task
+    ctx = decimal.Context()
+
+    # 12 digits should be enough to represent a single sample of
+    # 192khz in float
+    ctx.prec = precision
+
+    d1 = ctx.create_decimal(repr(f))
+    return format(d1, 'f')
 
 
 class Info(object):
@@ -151,11 +170,11 @@ def read_stems(
         ]
         if start:
             cmd.insert(3, '-ss')
-            cmd.insert(4, str(start))
+            cmd.insert(4, float_to_str(start))
 
         if duration is not None:
             cmd.insert(-1, '-t')
-            cmd.insert(-1, str(duration))
+            cmd.insert(-1, float_to_str(duration))
 
         sp.call(cmd)
         # read wav files

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -8,12 +8,12 @@ def dtype(request):
     return request.param
 
 
-@pytest.fixture(params=[None, 0, 1, 2, 100])
+@pytest.fixture(params=[None, 0, 0.000001, 1, 2, 100])
 def start(request):
     return request.param
 
 
-@pytest.fixture(params=[None, 0.5, 1, 2])
+@pytest.fixture(params=[None, 0.5, 1, 2, 2.00000000000001])
 def duration(request):
     return request.param
 
@@ -51,7 +51,7 @@ def test_duration(start, duration):
             duration=duration
         )
         if duration is not None:
-            assert S.shape[1] == duration * rate
+            assert S.shape[1] == int(duration * rate)
 
 
 def test_outtype(dtype):


### PR DESCRIPTION
```python
stempeg.read_steams(..., start=1e-6)
```

was causing an error since ffmpeg is expecting floating point string representation. This PR fixes the behavior and bump up the version