### PR TITLE
Centralize detection of ffmpeg executables

### DIFF
--- a/stempeg/__init__.py
+++ b/stempeg/__init__.py
@@ -3,6 +3,7 @@ from .read import read_info
 from .read import Info
 from .write import write_stems
 from .write import check_available_aac_encoders
+from .ffmpeg import FFMPEG_PATH, FFPROBE_PATH
 
 import re
 import os
@@ -14,26 +15,6 @@ import pkg_resources
 import shutil
 
 __version__ = "0.1.8"
-
-
-def cmd_exist(cmd):
-    try:
-        from shutil import which
-        return shutil.which(cmd) is not None
-    except ImportError:
-        return any(
-            os.access(os.path.join(path, cmd), os.X_OK)
-            for path in os.environ["PATH"].split(os.pathsep)
-        )
-
-def ffmpeg_and_ffprobe_exists():
-    return cmd_exist("ffmpeg") and cmd_exist("ffprobe")
-
-
-if not ffmpeg_and_ffprobe_exists():
-    raise RuntimeError('ffmpeg or ffprobe could not be found! '
-                       'Please install them before using stempeg. '
-                       'See: https://github.com/faroit/stempeg')
 
 
 def example_stem_path():
@@ -60,7 +41,7 @@ def ffmpeg_version():
     """
 
     cmd = [
-        'ffmpeg',
+        FFMPEG_PATH,
         '-version'
     ]
 

--- a/stempeg/ffmpeg.py
+++ b/stempeg/ffmpeg.py
@@ -1,0 +1,30 @@
+FFMPEG_PATH = None
+FFPROBE_PATH = None
+
+def find_cmd(cmd):
+    try:
+        from shutil import which
+        return which(cmd)
+    except ImportError:
+        import os
+        for path in os.environ["PATH"].split(os.pathsep):
+            if os.access(os.path.join(path, cmd), os.X_OK):
+                return path
+
+    return None
+
+def ffmpeg_and_ffprobe_exists():
+    global FFMPEG_PATH, FFPROBE_PATH
+    if FFMPEG_PATH is None:
+        FFMPEG_PATH = find_cmd("ffmpeg")
+
+    if FFPROBE_PATH is None:
+        FFPROBE_PATH = find_cmd("ffprobe")
+
+    return FFMPEG_PATH is not None and FFPROBE_PATH is not None
+
+if not ffmpeg_and_ffprobe_exists():
+    raise RuntimeError('ffmpeg or ffprobe could not be found! '
+                       'Please install them before using stempeg. '
+                       'See: https://github.com/faroit/stempeg')
+

--- a/stempeg/read.py
+++ b/stempeg/read.py
@@ -6,6 +6,7 @@ import warnings
 import tempfile as tmp
 import decimal
 import soundfile as sf
+from .ffmpeg import FFMPEG_PATH, FFPROBE_PATH
 
 DEVNULL = open(os.devnull, 'w')
 
@@ -83,7 +84,7 @@ def read_info(
     """
 
     cmd = [
-        'ffprobe',
+        FFPROBE_PATH,
         filename,
         '-v', 'error',
         '-print_format', 'json',
@@ -162,7 +163,7 @@ def read_stems(
         rate = FFinfo.rate(stem)
         channels = FFinfo.channels(stem)
         cmd = [
-            'ffmpeg',
+            FFMPEG_PATH,
             '-y',
             '-vn',
             '-i', filename,

--- a/stempeg/write.py
+++ b/stempeg/write.py
@@ -5,6 +5,7 @@ from itertools import chain
 import warnings
 import re
 import stempeg
+from .ffmpeg import FFMPEG_PATH, FFPROBE_PATH
 
 
 def check_available_aac_encoders():
@@ -17,7 +18,7 @@ def check_available_aac_encoders():
     """
 
     cmd = [
-        'ffmpeg',
+        FFMPEG_PATH,
         '-v', 'error',
         '-codecs'
     ]
@@ -102,7 +103,7 @@ def write_stems(
 
     cmd = (
         [
-            'ffmpeg', '-y',
+            FFMPEG_PATH, '-y',
             "-f", 's%dle' % (16),
             "-acodec", 'pcm_s%dle' % (16),
             '-ar', "%d" % rate,


### PR DESCRIPTION
In some distributions (e.g. NixOS) ffmpeg is not necessarily in PATH. Unifying
detection of the ffmpeg and ffprobe executables makes it easier for packagers
to patch the package to accomodate such situations.