### PR TITLE
fix dithering when exporting to float

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='stempeg',
-    version='0.2.1',
+    version='0.2.2',
     description='Read and write stem/multistream audio files',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/stempeg/__init__.py
+++ b/stempeg/__init__.py
@@ -29,7 +29,7 @@ from os import path as op
 import argparse
 import pkg_resources
 
-__version__ = "0.2.0"
+__version__ = "0.2.2"
 
 
 def example_stem_path():


### PR DESCRIPTION
In the last version of stempeg the method to load PCM through python-ffmpeg resulted in small differences to what I obtained with the previous version of stempeg.

This PR reverts the casting procedure for int16 to float32 + normalization `[-1, 1]`. This is important since dithering errors did significantly influence separation scores in regression tests.

With this PR, ffmpeg pipes int16 into the numpy buffer and is converted and normalized to float in numpy. This got the same results as I used to have before where I used temporarly wav files, converting to float32 using soundfile.
Furthermore, when using int16 pipes, conversion is slightly faster.

Also ping @romi1502 and @mmoussallam since this function originally derived from spleeters code. You might want to change it there as well.